### PR TITLE
Allow tags or indices

### DIFF
--- a/src/diffcalc_API/models/UBCalculation.py
+++ b/src/diffcalc_API/models/UBCalculation.py
@@ -41,3 +41,7 @@ class editOrientationParams(BaseModel):
     xyz: Optional[Tuple[float, float, float]] = None
     position: Optional[Tuple[float, float, float, float, float, float]] = None
     tagOrIdx: Union[int, str]
+
+
+class deleteParams(BaseModel):
+    tagOrIdx: Union[int, str]

--- a/src/diffcalc_API/routes/UBCalculation.py
+++ b/src/diffcalc_API/routes/UBCalculation.py
@@ -18,17 +18,13 @@ from diffcalc_API.fileHandling import supplyPersist, unpickleHkl
 from diffcalc_API.models.UBCalculation import (
     addOrientationParams,
     addReflectionParams,
+    deleteParams,
     editOrientationParams,
     editReflectionParams,
     setLatticeParams,
 )
 
 router = APIRouter(prefix="/ub", tags=["ub"])
-
-
-@router.get("/")
-async def read_main():
-    return {"msg": "Hello World"}
 
 
 @router.put("/{name}/reflection")
@@ -54,7 +50,12 @@ async def add_reflection(
     )
 
     persist(hklCalc, name)
-    return {"message": f"added reflection for UB Calculation of crystal {name}"}
+    return {
+        "message": (
+            f"added reflection for UB Calculation of crystal {name}. "
+            f"Reflist is: {hklCalc.ubcalc.reflist.reflections}"
+        )
+    }
 
 
 @router.put("/{name}/orientation")
@@ -111,7 +112,6 @@ async def edit_reflection(
     persist: Callable[[HklCalculation, str], Path] = Depends(supplyPersist),
 ):
     reflection = get_reflection(hklCalc, params.tagOrIdx)
-
     hklCalc.ubcalc.edit_reflection(
         params.tagOrIdx,
         params.hkl if params.hkl else (reflection.h, reflection.k, reflection.l),
@@ -189,10 +189,12 @@ async def calculate_UB(
 @router.delete("/{name}/reflection")
 async def delete_reflection(
     name: str,
-    tagOrIdx: Union[str, int] = Body(..., example="refl1"),
+    tagOrIdx: deleteParams = Body(..., example={"tagOrIdx": "refl1"}),
     hklCalc: HklCalculation = Depends(unpickleHkl),
     persist: Callable[[HklCalculation, str], Path] = Depends(supplyPersist),
 ):
+    print(tagOrIdx)
+    print(type(tagOrIdx))
     _ = get_reflection(hklCalc, tagOrIdx)
     hklCalc.ubcalc.del_reflection(tagOrIdx)
     persist(hklCalc, name)
@@ -203,7 +205,7 @@ async def delete_reflection(
 @router.delete("/{name}/orientation")
 async def delete_orientation(
     name: str,
-    tagOrIdx: Union[str, int] = Body(..., example="plane"),
+    tagOrIdx: deleteParams = Body(..., example={"tagOrIdx": "plane"}),
     hklCalc: HklCalculation = Depends(unpickleHkl),
     persist: Callable[[HklCalculation, str], Path] = Depends(supplyPersist),
 ):

--- a/src/diffcalc_API/routes/UBCalculation.py
+++ b/src/diffcalc_API/routes/UBCalculation.py
@@ -189,28 +189,26 @@ async def calculate_UB(
 @router.delete("/{name}/reflection")
 async def delete_reflection(
     name: str,
-    tagOrIdx: deleteParams = Body(..., example={"tagOrIdx": "refl1"}),
+    params: deleteParams = Body(..., example={"tagOrIdx": "refl1"}),
     hklCalc: HklCalculation = Depends(unpickleHkl),
     persist: Callable[[HklCalculation, str], Path] = Depends(supplyPersist),
 ):
-    print(tagOrIdx)
-    print(type(tagOrIdx))
-    _ = get_reflection(hklCalc, tagOrIdx)
-    hklCalc.ubcalc.del_reflection(tagOrIdx)
+    _ = get_reflection(hklCalc, params.tagOrIdx)
+    hklCalc.ubcalc.del_reflection(params.tagOrIdx)
     persist(hklCalc, name)
 
-    return {"message": f"reflection with tag or index {tagOrIdx} deleted."}
+    return {"message": f"reflection with tag or index {params.tagOrIdx} deleted."}
 
 
 @router.delete("/{name}/orientation")
 async def delete_orientation(
     name: str,
-    tagOrIdx: deleteParams = Body(..., example={"tagOrIdx": "plane"}),
+    params: deleteParams = Body(..., example={"tagOrIdx": "plane"}),
     hklCalc: HklCalculation = Depends(unpickleHkl),
     persist: Callable[[HklCalculation, str], Path] = Depends(supplyPersist),
 ):
-    _ = get_orientation(hklCalc, tagOrIdx)
-    hklCalc.ubcalc.del_orientation(tagOrIdx)
+    _ = get_orientation(hklCalc, params.tagOrIdx)
+    hklCalc.ubcalc.del_orientation(params.tagOrIdx)
     persist(hklCalc, name)
 
-    return {"message": f"reflection with tag or index {tagOrIdx} deleted."}
+    return {"message": f"reflection with tag or index {params.tagOrIdx} deleted."}

--- a/tests/test_diffcalc_API.py
+++ b/tests/test_diffcalc_API.py
@@ -1,5 +1,0 @@
-# do tests here...
-
-
-def test_dummy():
-    pass

--- a/tests/test_ubcalc.py
+++ b/tests/test_ubcalc.py
@@ -68,7 +68,7 @@ def test_edit_reflection(client: TestClient):
 
 def test_delete_reflection(client: TestClient):
     dummyHkl.ubcalc.add_reflection([0, 0, 1], Position(7, 0, 10, 0, 0, 0), 12, "foo")
-    response = client.delete("/ub/test/reflection", json="foo")
+    response = client.delete("/ub/test/reflection", json={"tagOrIdx": "foo"})
 
     assert response.status_code == 200
     with pytest.raises(Exception):
@@ -87,7 +87,7 @@ def test_edit_or_delete_reflection_fails_for_non_existing_reflection(
     )
     deleteResponse = client.delete(
         "/ub/test/reflection",
-        json="foo",
+        json={"tagOrIdx": "foo"},
     )
 
     assert editResponse.status_code == codes.get_reflection
@@ -134,7 +134,7 @@ def test_delete_orientation(client: TestClient):
     dummyHkl.ubcalc.add_orientation([0, 0, 1], [0, 0, 1], None, "bar")
     response = client.delete(
         "/ub/test/orientation",
-        json="bar",
+        json={"tagOrIdx": "bar"},
     )
 
     assert response.status_code == 200
@@ -154,7 +154,7 @@ def test_edit_or_delete_orientation_fails_for_non_existing_orientation(
     )
     deleteResponse = client.delete(
         "/ub/test/orientation",
-        json="bar",
+        json={"tagOrIdx": "bar"},
     )
 
     assert editResponse.status_code == codes.get_orientation


### PR DESCRIPTION
Some of my routes in routes/UBCalculation.py delete or edit orientations/reflections in a pickled HklCalculation object. In Irakli's code, this can be done with both a tag for the desired orientation/reflection, and an index. 

I have made changes to do the same here, so that the client using this API can request for an index in the list of orientations/reflections to be deleted, OR for a specific tag of orientations/reflections to be deleted. This worked with editing orientations/reflections because the tagOrIdx parameter was wrapped in a pydantic model - I've since realised that I needed to do the same for my delete routes as well, so I have made a simple deleteParams pydantic model to hold this information.

As a result, some tests have also changed. I have deleted the test_diffcalc_API.py file as well, as this was a dummy file.