### PR TITLE
removed tuples from all route parameters and base model definitions

### DIFF
--- a/src/diffcalc_API/errors/hkl.py
+++ b/src/diffcalc_API/errors/hkl.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 import numpy as np
 
 from diffcalc_API.errors.definitions import (
@@ -16,8 +18,10 @@ responses = {code: ALL_RESPONSES[code] for code in np.unique(ErrorCodes.all_code
 
 
 class InvalidMillerIndicesError(DiffcalcAPIException):
-    def __init__(self) -> None:
-        self.detail = "At least one of the hkl indices must be non-zero"
+    def __init__(self, detail: Optional[str] = None) -> None:
+        self.detail = (
+            "At least one of the hkl indices must be non-zero" if not detail else detail
+        )
         self.status_code = ErrorCodes.INVALID_MILLER_INDICES
 
 

--- a/src/diffcalc_API/examples/ub.py
+++ b/src/diffcalc_API/examples/ub.py
@@ -3,13 +3,16 @@ from diffcalc_API.models.ub import (
     AddReflectionParams,
     EditOrientationParams,
     EditReflectionParams,
+    HklModel,
+    PositionModel,
     SetLatticeParams,
+    XyzModel,
 )
 
 add_reflection: AddReflectionParams = AddReflectionParams(
     **{
-        "hkl": [0, 0, 1],
-        "position": [7.31, 0.0, 10.62, 0, 0.0, 0],
+        "hkl": HklModel(h=0, k=0, l=1),
+        "position": PositionModel(mu=7.31, delta=0.0, nu=10.62, eta=0, chi=0.0, phi=0),
         "energy": 12.39842,
         "tag": "refl1",
     }
@@ -21,15 +24,15 @@ edit_reflection: EditReflectionParams = EditReflectionParams(
 
 add_orientation: AddOrientationParams = AddOrientationParams(
     **{
-        "hkl": [0, 1, 0],
-        "xyz": [0, 1, 0],
+        "hkl": HklModel(h=0, k=1, l=0),
+        "xyz": XyzModel(x=0, y=1, z=0),
         "tag": "plane",
     }
 )
 
 edit_orientation: EditOrientationParams = EditOrientationParams(
     **{
-        "hkl": (0, 1, 0),
+        "hkl": HklModel(h=0, k=1, l=0),
         "tag_or_idx": "plane",
     }
 )

--- a/src/diffcalc_API/models/ub.py
+++ b/src/diffcalc_API/models/ub.py
@@ -1,6 +1,27 @@
-from typing import Optional, Tuple, Union
+from typing import Optional, Union
 
 from pydantic import BaseModel
+
+
+class HklModel(BaseModel):
+    h: float
+    k: float
+    l: float
+
+
+class XyzModel(BaseModel):
+    x: float
+    y: float
+    z: float
+
+
+class PositionModel(BaseModel):
+    mu: float
+    delta: float
+    nu: float
+    eta: float
+    chi: float
+    phi: float
 
 
 class SetLatticeParams(BaseModel):
@@ -14,32 +35,30 @@ class SetLatticeParams(BaseModel):
 
 
 class AddReflectionParams(BaseModel):
-    hkl: Tuple[float, float, float]
-    position: Tuple[
-        float, float, float, float, float, float
-    ]  # allows easier user input
+    hkl: HklModel
+    position: PositionModel
     energy: float
     tag: Optional[str] = None
 
 
 class AddOrientationParams(BaseModel):
-    hkl: Tuple[float, float, float]
-    xyz: Tuple[float, float, float]
-    position: Optional[Tuple[float, float, float, float, float, float]] = None
+    hkl: HklModel
+    xyz: XyzModel
+    position: Optional[PositionModel] = None
     tag: Optional[str] = None
 
 
 class EditReflectionParams(BaseModel):
-    hkl: Optional[Tuple[float, float, float]] = None
-    position: Optional[Tuple[float, float, float, float, float, float]] = None
+    hkl: Optional[HklModel] = None
+    position: Optional[PositionModel] = None
     energy: Optional[float] = None
     tag_or_idx: Union[int, str]
 
 
 class EditOrientationParams(BaseModel):
-    hkl: Optional[Tuple[float, float, float]] = None
-    xyz: Optional[Tuple[float, float, float]] = None
-    position: Optional[Tuple[float, float, float, float, float, float]] = None
+    hkl: Optional[HklModel] = None
+    xyz: Optional[XyzModel] = None
+    position: Optional[PositionModel] = None
     tag_or_idx: Union[int, str]
 
 

--- a/src/diffcalc_API/routes/hkl.py
+++ b/src/diffcalc_API/routes/hkl.py
@@ -1,15 +1,12 @@
-from typing import Optional, Tuple, Union
+from typing import List, Optional, Union
 
 from fastapi import APIRouter, Depends, Query
 
+from diffcalc_API.models.ub import HklModel, PositionModel
 from diffcalc_API.services import hkl as service
 from diffcalc_API.stores.protocol import HklCalcStore, get_store
 
 router = APIRouter(prefix="/hkl", tags=["hkl"])
-
-
-SingleConstraint = Union[Tuple[str, float], str]
-PositionType = Tuple[float, float, float]
 
 
 @router.get("/{name}/UB")
@@ -27,7 +24,8 @@ async def calculate_ub(
 @router.get("/{name}/position/lab")
 async def lab_position_from_miller_indices(
     name: str,
-    miller_indices: Tuple[float, float, float] = Query(example=[0, 0, 1]),
+    # miller_indices: List[float] = Query(example=[0, 0, 1]),
+    miller_indices: HklModel = Depends(),
     wavelength: float = Query(..., example=1.0),
     store: HklCalcStore = Depends(get_store),
     collection: Optional[str] = Query(default=None, example="B07"),
@@ -42,8 +40,9 @@ async def lab_position_from_miller_indices(
 @router.get("/{name}/position/hkl")
 async def miller_indices_from_lab_position(
     name: str,
-    pos: Tuple[float, float, float, float, float, float] = Query(
-        ..., example=[7.31, 0, 10.62, 0, 0, 0]
+    pos: PositionModel = Depends(
+        # ..., example={"mu": 7.31, "delta": 0, "nu": 10.62,
+        # "eta": 0, "chi": 0, "phi": 0}
     ),
     wavelength: float = Query(..., example=1.0),
     store: HklCalcStore = Depends(get_store),
@@ -58,9 +57,9 @@ async def miller_indices_from_lab_position(
 @router.get("/{name}/scan/hkl")
 async def scan_hkl(
     name: str,
-    start: PositionType = Query(..., example=(1, 0, 1)),
-    stop: PositionType = Query(..., example=(2, 0, 2)),
-    inc: PositionType = Query(..., example=(0.1, 0, 0.1)),
+    start: List[float] = Query(..., example=[1, 0, 1]),
+    stop: List[float] = Query(..., example=[2, 0, 2]),
+    inc: List[float] = Query(..., example=(0.1, 0, 0.1)),
     wavelength: float = Query(..., example=1),
     store: HklCalcStore = Depends(get_store),
     collection: Optional[str] = Query(default=None, example="B07"),
@@ -77,7 +76,8 @@ async def scan_wavelength(
     start: float = Query(..., example=1.0),
     stop: float = Query(..., example=2.0),
     inc: float = Query(..., example=0.2),
-    hkl: PositionType = Query(..., example=(1, 0, 1)),
+    #    hkl: PositionType = Query(..., example=(1, 0, 1)),
+    hkl: HklModel = Depends(),
     store: HklCalcStore = Depends(get_store),
     collection: Optional[str] = Query(default=None, example="B07"),
 ):
@@ -94,7 +94,8 @@ async def scan_constraint(
     start: float = Query(..., example=1),
     stop: float = Query(..., example=4),
     inc: float = Query(..., example=1),
-    hkl: PositionType = Query(..., example=(1, 0, 1)),
+    #    hkl: PositionType = Query(..., example=(1, 0, 1)),
+    hkl: HklModel = Depends(),
     wavelength: float = Query(..., example=1.0),
     store: HklCalcStore = Depends(get_store),
     collection: Optional[str] = Query(default=None, example="B07"),

--- a/src/diffcalc_API/routes/ub.py
+++ b/src/diffcalc_API/routes/ub.py
@@ -1,4 +1,4 @@
-from typing import Optional, Tuple
+from typing import Optional
 
 from fastapi import APIRouter, Body, Depends, Query
 
@@ -11,6 +11,7 @@ from diffcalc_API.models.ub import (
     DeleteParams,
     EditOrientationParams,
     EditReflectionParams,
+    HklModel,
     SetLatticeParams,
 )
 from diffcalc_API.services import ub as service
@@ -152,7 +153,7 @@ async def set_lattice(
 async def modify_property(
     name: str,
     property: str,
-    target_value: Tuple[float, float, float] = Body(..., example=[1, 0, 0]),
+    target_value: HklModel = Body(..., example={"h": 1, "k": 0, "l": 0}),
     store: HklCalcStore = Depends(get_store),
     collection: Optional[str] = Query(default=None, example="B07"),
 ):

--- a/src/diffcalc_API/server.py
+++ b/src/diffcalc_API/server.py
@@ -1,3 +1,4 @@
+import traceback
 from typing import Optional
 
 from diffcalc.util import DiffcalcException
@@ -46,6 +47,8 @@ async def server_exceptions_middleware(request: Request, call_next):
         return await call_next(request)
     except Exception as e:
         # you probably want some kind of logging here
+        tb = traceback.format_exc()
+        print(tb)
 
         return responses.JSONResponse(
             status_code=500,

--- a/tests/test_ubcalc.py
+++ b/tests/test_ubcalc.py
@@ -55,8 +55,8 @@ def test_add_reflection(client: TestClient):
     response = client.post(
         "/ub/test/reflection",
         json={
-            "hkl": [0, 0, 1],
-            "position": [7, 0, 10, 0, 0, 0],
+            "hkl": {"h": 0, "k": 0, "l": 1},
+            "position": {"mu": 7, "delta": 0, "nu": 10, "eta": 0, "chi": 0, "phi": 0},
             "energy": 12,
             "tag": "foo",
         },
@@ -117,8 +117,8 @@ def test_add_orientation(client: TestClient):
     response = client.post(
         "/ub/test/orientation",
         json={
-            "hkl": [0, 1, 0],
-            "xyz": [0, 1, 0],
+            "hkl": {"h": 0, "k": 1, "l": 0},
+            "xyz": {"x": 0, "y": 1, "z": 0},
             "tag": "bar",
         },
     )
@@ -134,7 +134,7 @@ def test_edit_orientation(client: TestClient):
     response = client.put(
         "/ub/test/orientation",
         json={
-            "xyz": [1, 1, 0],
+            "xyz": {"x": 1, "y": 1, "z": 0},
             "tag_or_idx": "bar",
         },
     )
@@ -167,7 +167,7 @@ def test_edit_or_delete_orientation_fails_for_non_existing_orientation(
     edit_response = client.put(
         "/ub/test/orientation",
         json={
-            "xyz": [1, 1, 0],
+            "xyz": {"x": 1, "y": 1, "z": 0},
             "tag_or_idx": "bar",
         },
     )
@@ -210,7 +210,7 @@ def test_set_lattice_fails_for_empty_data(client: TestClient):
 def test_modify_property(client: TestClient):
     response = client.put(
         "/ub/test/n_hkl",
-        json=[0, 0, 1],
+        json={"h": 0, "k": 0, "l": 1},
     )
 
     assert response.status_code == 200
@@ -220,6 +220,6 @@ def test_modify_property(client: TestClient):
 def test_modify_non_existent_property(client: TestClient):
     response = client.put(
         "/ub/test/silly_property",
-        json=[0, 0, 1],
+        json={"h": 0, "k": 0, "l": 1},
     )
     assert response.status_code == ErrorCodes.INVALID_PROPERTY


### PR DESCRIPTION
This PR is necessary because currently fastAPI does not support typing.Tuples. In order to work around this, I redefined my pydantic models to instead use other pydantic models (essentially, dataclasses) with explicit members. Where this was not possible (e.g. routes/hkl, for the scan_hkl route), I added errors to catch incorrect parameters instead.

This is part of a larger work to make swagger-codegen outputs for a java client better - Tuples are not correctly translated to an openapi schema.