### PR TITLE
Remove unions in params and delete request body

### DIFF
--- a/src/diffcalc_API/errors/hkl.py
+++ b/src/diffcalc_API/errors/hkl.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 import numpy as np
 
 from diffcalc_API.errors.definitions import (
@@ -16,8 +18,10 @@ responses = {code: ALL_RESPONSES[code] for code in np.unique(ErrorCodes.all_code
 
 
 class InvalidMillerIndicesError(DiffcalcAPIException):
-    def __init__(self) -> None:
-        self.detail = "At least one of the hkl indices must be non-zero"
+    def __init__(self, detail: Optional[str] = None) -> None:
+        self.detail = (
+            "At least one of the hkl indices must be non-zero" if not detail else detail
+        )
         self.status_code = ErrorCodes.INVALID_MILLER_INDICES
 
 

--- a/src/diffcalc_API/errors/ub.py
+++ b/src/diffcalc_API/errors/ub.py
@@ -15,6 +15,7 @@ class ErrorCodes(ErrorCodesBase):
     REFERENCE_RETRIEVAL_ERROR = 403
     INVALID_PROPERTY = 400
     NO_TAG_OR_IDX_PROVIDED = 400
+    BOTH_TAG_OR_IDX_PROVIDED = 400
 
 
 responses = {code: ALL_RESPONSES[code] for code in np.unique(ErrorCodes.all_codes())}
@@ -27,6 +28,16 @@ class NoTagOrIdxProvidedError(DiffcalcAPIException):
             + " tag (string), index (integer)"
         )
         self.status_code = ErrorCodes.NO_TAG_OR_IDX_PROVIDED
+
+
+class BothTagAndIdxProvidedError(DiffcalcAPIException):
+    def __init__(self):
+        self.detail = (
+            "both the tag and index have been provided. These are identifiers"
+            + "for a specific orientation or reflection, and so both cannot be"
+            + "used. Retry with just one tag or index query parameter."
+        )
+        self.status_code = ErrorCodes.BOTH_TAG_OR_IDX_PROVIDED
 
 
 class InvalidSetLatticeParamsError(DiffcalcAPIException):

--- a/src/diffcalc_API/errors/ub.py
+++ b/src/diffcalc_API/errors/ub.py
@@ -34,8 +34,8 @@ class BothTagAndIdxProvidedError(DiffcalcAPIException):
     def __init__(self):
         self.detail = (
             "both the tag and index have been provided. These are identifiers"
-            + "for a specific orientation or reflection, and so both cannot be"
-            + "used. Retry with just one tag or index query parameter."
+            + " for a specific orientation or reflection, and so both cannot be"
+            + " used. Retry with just one tag or index query parameter."
         )
         self.status_code = ErrorCodes.BOTH_TAG_OR_IDX_PROVIDED
 

--- a/src/diffcalc_API/errors/ub.py
+++ b/src/diffcalc_API/errors/ub.py
@@ -1,4 +1,4 @@
-from typing import Union
+from typing import Optional, Union
 
 import numpy as np
 
@@ -14,9 +14,19 @@ class ErrorCodes(ErrorCodesBase):
     INVALID_SET_LATTICE_PARAMS = 400
     REFERENCE_RETRIEVAL_ERROR = 403
     INVALID_PROPERTY = 400
+    NO_TAG_OR_IDX_PROVIDED = 400
 
 
 responses = {code: ALL_RESPONSES[code] for code in np.unique(ErrorCodes.all_codes())}
+
+
+class NoTagOrIdxProvidedError(DiffcalcAPIException):
+    def __init__(self):
+        self.detail = (
+            "One of the following must be provided as a query parameter:"
+            + " tag (string), index (integer)"
+        )
+        self.status_code = ErrorCodes.NO_TAG_OR_IDX_PROVIDED
 
 
 class InvalidSetLatticeParamsError(DiffcalcAPIException):
@@ -26,7 +36,7 @@ class InvalidSetLatticeParamsError(DiffcalcAPIException):
 
 
 class ReferenceRetrievalError(DiffcalcAPIException):
-    def __init__(self, handle: Union[str, int], reference_type: str) -> None:
+    def __init__(self, handle: Optional[Union[str, int]], reference_type: str) -> None:
         self.detail = f"cannot retrieve {reference_type} with tag or index {handle}"
         self.status_code = ErrorCodes.REFERENCE_RETRIEVAL_ERROR
 

--- a/src/diffcalc_API/examples/ub.py
+++ b/src/diffcalc_API/examples/ub.py
@@ -31,7 +31,6 @@ add_orientation: AddOrientationParams = AddOrientationParams(
 edit_orientation: EditOrientationParams = EditOrientationParams(
     **{
         "hkl": HklModel(h=0, k=1, l=0),
-        "retrieve_idx": 0,
     }
 )
 

--- a/src/diffcalc_API/examples/ub.py
+++ b/src/diffcalc_API/examples/ub.py
@@ -19,7 +19,7 @@ add_reflection: AddReflectionParams = AddReflectionParams(
 )
 
 edit_reflection: EditReflectionParams = EditReflectionParams(
-    **{"energy": 12.45, "tag_or_idx": "refl1"}
+    **{"energy": 12.45, "retrieve_tag": "refl1", "set_tag": "refl2"}
 )
 
 add_orientation: AddOrientationParams = AddOrientationParams(
@@ -33,7 +33,7 @@ add_orientation: AddOrientationParams = AddOrientationParams(
 edit_orientation: EditOrientationParams = EditOrientationParams(
     **{
         "hkl": HklModel(h=0, k=1, l=0),
-        "tag_or_idx": "plane",
+        "retrieve_idx": 0,
     }
 )
 

--- a/src/diffcalc_API/examples/ub.py
+++ b/src/diffcalc_API/examples/ub.py
@@ -14,19 +14,17 @@ add_reflection: AddReflectionParams = AddReflectionParams(
         "hkl": HklModel(h=0, k=0, l=1),
         "position": PositionModel(mu=7.31, delta=0.0, nu=10.62, eta=0, chi=0.0, phi=0),
         "energy": 12.39842,
-        "tag": "refl1",
     }
 )
 
 edit_reflection: EditReflectionParams = EditReflectionParams(
-    **{"energy": 12.45, "retrieve_tag": "refl1", "set_tag": "refl2"}
+    **{"energy": 12.45, "set_tag": "refl2"}
 )
 
 add_orientation: AddOrientationParams = AddOrientationParams(
     **{
         "hkl": HklModel(h=0, k=1, l=0),
         "xyz": XyzModel(x=0, y=1, z=0),
-        "tag": "plane",
     }
 )
 

--- a/src/diffcalc_API/examples/ub.py
+++ b/src/diffcalc_API/examples/ub.py
@@ -3,13 +3,16 @@ from diffcalc_API.models.ub import (
     AddReflectionParams,
     EditOrientationParams,
     EditReflectionParams,
+    HklModel,
+    PositionModel,
     SetLatticeParams,
+    XyzModel,
 )
 
 add_reflection: AddReflectionParams = AddReflectionParams(
     **{
-        "hkl": [0, 0, 1],
-        "position": [7.31, 0.0, 10.62, 0, 0.0, 0],
+        "hkl": HklModel(h=0, k=0, l=1),
+        "position": PositionModel(mu=7.31, delta=0.0, nu=10.62, eta=0, chi=0.0, phi=0),
         "energy": 12.39842,
         "tag": "refl1",
     }
@@ -21,15 +24,15 @@ edit_reflection: EditReflectionParams = EditReflectionParams(
 
 add_orientation: AddOrientationParams = AddOrientationParams(
     **{
-        "hkl": [0, 1, 0],
-        "xyz": [0, 1, 0],
+        "hkl": HklModel(h=0, k=1, l=0),
+        "xyz": XyzModel(x=0, y=1, z=0),
         "tag": "plane",
     }
 )
 
 edit_orientation: EditOrientationParams = EditOrientationParams(
     **{
-        "hkl": (0, 1, 0),
+        "hkl": HklModel(h=0, k=1, l=0),
         "tag_or_idx": "plane",
     }
 )

--- a/src/diffcalc_API/models/ub.py
+++ b/src/diffcalc_API/models/ub.py
@@ -1,6 +1,27 @@
-from typing import Optional, Tuple, Union
+from typing import Optional, Union
 
 from pydantic import BaseModel
+
+
+class HklModel(BaseModel):
+    h: float
+    k: float
+    l: float
+
+
+class XyzModel(BaseModel):
+    x: float
+    y: float
+    z: float
+
+
+class PositionModel(BaseModel):
+    mu: float
+    delta: float
+    nu: float
+    eta: float
+    chi: float
+    phi: float
 
 
 class SetLatticeParams(BaseModel):
@@ -14,32 +35,30 @@ class SetLatticeParams(BaseModel):
 
 
 class AddReflectionParams(BaseModel):
-    hkl: Tuple[float, float, float]
-    position: Tuple[
-        float, float, float, float, float, float
-    ]  # allows easier user input
+    hkl: HklModel
+    position: PositionModel
     energy: float
     tag: Optional[str] = None
 
 
 class AddOrientationParams(BaseModel):
-    hkl: Tuple[float, float, float]
-    xyz: Tuple[float, float, float]
-    position: Optional[Tuple[float, float, float, float, float, float]] = None
+    hkl: HklModel
+    xyz: XyzModel
+    position: Optional[PositionModel] = None
     tag: Optional[str] = None
 
 
 class EditReflectionParams(BaseModel):
-    hkl: Optional[Tuple[float, float, float]] = None
-    position: Optional[Tuple[float, float, float, float, float, float]] = None
+    hkl: Optional[HklModel] = None
+    position: Optional[PositionModel] = None
     energy: Optional[float] = None
     tag_or_idx: Union[int, str]
 
 
 class EditOrientationParams(BaseModel):
-    hkl: Optional[Tuple[float, float, float]] = None
-    xyz: Optional[Tuple[float, float, float]] = None
-    position: Optional[Tuple[float, float, float, float, float, float]] = None
+    hkl: Optional[HklModel] = None
+    xyz: Optional[XyzModel] = None
+    position: Optional[PositionModel] = None
     tag_or_idx: Union[int, str]
 
 

--- a/src/diffcalc_API/models/ub.py
+++ b/src/diffcalc_API/models/ub.py
@@ -1,6 +1,5 @@
 from typing import Optional
 
-
 from pydantic import BaseModel
 
 

--- a/src/diffcalc_API/models/ub.py
+++ b/src/diffcalc_API/models/ub.py
@@ -52,15 +52,15 @@ class EditReflectionParams(BaseModel):
     hkl: Optional[HklModel] = None
     position: Optional[PositionModel] = None
     energy: Optional[float] = None
-    tag_or_idx: Union[int, str]
+    retrieve_tag: Optional[str] = None
+    retrieve_idx: Optional[int] = None
+    set_tag: Optional[str] = None
 
 
 class EditOrientationParams(BaseModel):
     hkl: Optional[HklModel] = None
     xyz: Optional[XyzModel] = None
     position: Optional[PositionModel] = None
-    tag_or_idx: Union[int, str]
-
-
-class DeleteParams(BaseModel):
-    tag_or_idx: Union[int, str]
+    retrieve_tag: Optional[str] = None
+    retrieve_idx: Optional[int] = None
+    set_tag: Optional[str] = None

--- a/src/diffcalc_API/models/ub.py
+++ b/src/diffcalc_API/models/ub.py
@@ -1,4 +1,4 @@
-from typing import Optional, Union
+from typing import Optional
 
 from pydantic import BaseModel
 
@@ -25,7 +25,7 @@ class PositionModel(BaseModel):
 
 
 class SetLatticeParams(BaseModel):
-    system: Optional[Union[str, float]] = None
+    system: Optional[str] = None
     a: Optional[float] = None
     b: Optional[float] = None
     c: Optional[float] = None
@@ -38,22 +38,18 @@ class AddReflectionParams(BaseModel):
     hkl: HklModel
     position: PositionModel
     energy: float
-    tag: Optional[str] = None
 
 
 class AddOrientationParams(BaseModel):
     hkl: HklModel
     xyz: XyzModel
     position: Optional[PositionModel] = None
-    tag: Optional[str] = None
 
 
 class EditReflectionParams(BaseModel):
     hkl: Optional[HklModel] = None
     position: Optional[PositionModel] = None
     energy: Optional[float] = None
-    retrieve_tag: Optional[str] = None
-    retrieve_idx: Optional[int] = None
     set_tag: Optional[str] = None
 
 
@@ -61,6 +57,8 @@ class EditOrientationParams(BaseModel):
     hkl: Optional[HklModel] = None
     xyz: Optional[XyzModel] = None
     position: Optional[PositionModel] = None
-    retrieve_tag: Optional[str] = None
-    retrieve_idx: Optional[int] = None
     set_tag: Optional[str] = None
+
+
+def select_idx_or_tag_str(idx: Optional[int], tag: Optional[str]):
+    return f"index {idx}" if idx is not None else f"tag {tag}"

--- a/src/diffcalc_API/routes/constraints.py
+++ b/src/diffcalc_API/routes/constraints.py
@@ -1,4 +1,4 @@
-from typing import Dict, Optional, Union
+from typing import Dict, Optional
 
 from fastapi import APIRouter, Body, Depends, Query
 
@@ -21,9 +21,7 @@ async def get_constraints(
 @router.post("/{name}")
 async def set_constraints(
     name: str,
-    constraints: Dict[str, Union[float, bool]] = Body(
-        example={"qaz": 0, "alpha": 0, "eta": 0}
-    ),
+    constraints: Dict[str, float] = Body(example={"qaz": 0, "alpha": 0, "eta": 0}),
     store: HklCalcStore = Depends(get_store),
     collection: Optional[str] = Query(default=None, example="B07"),
 ):
@@ -58,7 +56,7 @@ async def remove_constraint(
 async def set_constraint(
     name: str,
     property: str,
-    value: Union[float, bool] = Body(...),
+    value: float = Body(...),
     store: HklCalcStore = Depends(get_store),
     collection: Optional[str] = Query(default=None, example="B07"),
 ):

--- a/src/diffcalc_API/routes/hkl.py
+++ b/src/diffcalc_API/routes/hkl.py
@@ -1,6 +1,5 @@
 from typing import List, Optional
 
-
 from fastapi import APIRouter, Depends, Query
 
 from diffcalc_API.models.ub import HklModel, PositionModel

--- a/src/diffcalc_API/routes/hkl.py
+++ b/src/diffcalc_API/routes/hkl.py
@@ -24,7 +24,6 @@ async def calculate_ub(
 @router.get("/{name}/position/lab")
 async def lab_position_from_miller_indices(
     name: str,
-    # miller_indices: List[float] = Query(example=[0, 0, 1]),
     miller_indices: HklModel = Depends(),
     wavelength: float = Query(..., example=1.0),
     store: HklCalcStore = Depends(get_store),
@@ -40,10 +39,7 @@ async def lab_position_from_miller_indices(
 @router.get("/{name}/position/hkl")
 async def miller_indices_from_lab_position(
     name: str,
-    pos: PositionModel = Depends(
-        # ..., example={"mu": 7.31, "delta": 0, "nu": 10.62,
-        # "eta": 0, "chi": 0, "phi": 0}
-    ),
+    pos: PositionModel = Depends(),
     wavelength: float = Query(..., example=1.0),
     store: HklCalcStore = Depends(get_store),
     collection: Optional[str] = Query(default=None, example="B07"),
@@ -59,7 +55,7 @@ async def scan_hkl(
     name: str,
     start: List[float] = Query(..., example=[1, 0, 1]),
     stop: List[float] = Query(..., example=[2, 0, 2]),
-    inc: List[float] = Query(..., example=(0.1, 0, 0.1)),
+    inc: List[float] = Query(..., example=[0.1, 0, 0.1]),
     wavelength: float = Query(..., example=1),
     store: HklCalcStore = Depends(get_store),
     collection: Optional[str] = Query(default=None, example="B07"),
@@ -76,7 +72,6 @@ async def scan_wavelength(
     start: float = Query(..., example=1.0),
     stop: float = Query(..., example=2.0),
     inc: float = Query(..., example=0.2),
-    #    hkl: PositionType = Query(..., example=(1, 0, 1)),
     hkl: HklModel = Depends(),
     store: HklCalcStore = Depends(get_store),
     collection: Optional[str] = Query(default=None, example="B07"),
@@ -94,7 +89,6 @@ async def scan_constraint(
     start: float = Query(..., example=1),
     stop: float = Query(..., example=4),
     inc: float = Query(..., example=1),
-    #    hkl: PositionType = Query(..., example=(1, 0, 1)),
     hkl: HklModel = Depends(),
     wavelength: float = Query(..., example=1.0),
     store: HklCalcStore = Depends(get_store),

--- a/src/diffcalc_API/routes/hkl.py
+++ b/src/diffcalc_API/routes/hkl.py
@@ -1,4 +1,4 @@
-from typing import List, Optional, Union
+from typing import List, Optional
 
 from fastapi import APIRouter, Depends, Query
 
@@ -12,12 +12,16 @@ router = APIRouter(prefix="/hkl", tags=["hkl"])
 @router.get("/{name}/UB")
 async def calculate_ub(
     name: str,
-    first_tag: Optional[Union[int, str]] = Query(default=None, example="refl1"),
-    second_tag: Optional[Union[int, str]] = Query(default=None, example="plane"),
+    tag1: Optional[str] = Query(default=None, example="refl1"),
+    idx1: Optional[int] = Query(default=None),
+    tag2: Optional[str] = Query(default=None, example="plane"),
+    idx2: Optional[int] = Query(default=None),
     store: HklCalcStore = Depends(get_store),
     collection: Optional[str] = Query(default=None, example="B07"),
 ):
-    content = await service.calculate_ub(name, first_tag, second_tag, store, collection)
+    content = await service.calculate_ub(
+        name, store, collection, tag1, idx1, tag2, idx2
+    )
     return {"payload": content}
 
 

--- a/src/diffcalc_API/routes/hkl.py
+++ b/src/diffcalc_API/routes/hkl.py
@@ -1,15 +1,12 @@
-from typing import Optional, Tuple, Union
+from typing import List, Optional, Union
 
 from fastapi import APIRouter, Depends, Query
 
+from diffcalc_API.models.ub import HklModel, PositionModel
 from diffcalc_API.services import hkl as service
 from diffcalc_API.stores.protocol import HklCalcStore, get_store
 
 router = APIRouter(prefix="/hkl", tags=["hkl"])
-
-
-SingleConstraint = Union[Tuple[str, float], str]
-PositionType = Tuple[float, float, float]
 
 
 @router.get("/{name}/UB")
@@ -27,7 +24,8 @@ async def calculate_ub(
 @router.get("/{name}/position/lab")
 async def lab_position_from_miller_indices(
     name: str,
-    miller_indices: Tuple[float, float, float] = Query(example=[0, 0, 1]),
+    # miller_indices: List[float] = Query(example=[0, 0, 1]),
+    miller_indices: HklModel = Depends(),
     wavelength: float = Query(..., example=1.0),
     store: HklCalcStore = Depends(get_store),
     collection: Optional[str] = Query(default=None, example="B07"),
@@ -42,8 +40,9 @@ async def lab_position_from_miller_indices(
 @router.get("/{name}/position/hkl")
 async def miller_indices_from_lab_position(
     name: str,
-    pos: Tuple[float, float, float, float, float, float] = Query(
-        ..., example=[7.31, 0, 10.62, 0, 0, 0]
+    pos: PositionModel = Depends(
+        # ..., example={"mu": 7.31, "delta": 0, "nu": 10.62,
+        # "eta": 0, "chi": 0, "phi": 0}
     ),
     wavelength: float = Query(..., example=1.0),
     store: HklCalcStore = Depends(get_store),
@@ -58,9 +57,9 @@ async def miller_indices_from_lab_position(
 @router.get("/{name}/scan/hkl")
 async def scan_hkl(
     name: str,
-    start: PositionType = Query(..., example=(1, 0, 1)),
-    stop: PositionType = Query(..., example=(2, 0, 2)),
-    inc: PositionType = Query(..., example=(0.1, 0, 0.1)),
+    start: List[float] = Query(..., example=[1, 0, 1]),
+    stop: List[float] = Query(..., example=[2, 0, 2]),
+    inc: List[float] = Query(..., example=(0.1, 0, 0.1)),
     wavelength: float = Query(..., example=1),
     store: HklCalcStore = Depends(get_store),
     collection: Optional[str] = Query(default=None, example="B07"),
@@ -77,7 +76,8 @@ async def scan_wavelength(
     start: float = Query(..., example=1.0),
     stop: float = Query(..., example=2.0),
     inc: float = Query(..., example=0.2),
-    hkl: PositionType = Query(..., example=(1, 0, 1)),
+    #    hkl: PositionType = Query(..., example=(1, 0, 1)),
+    hkl: HklModel = Depends(),
     store: HklCalcStore = Depends(get_store),
     collection: Optional[str] = Query(default=None, example="B07"),
 ):
@@ -94,7 +94,8 @@ async def scan_constraint(
     start: float = Query(..., example=1),
     stop: float = Query(..., example=4),
     inc: float = Query(..., example=1),
-    hkl: PositionType = Query(..., example=(1, 0, 1)),
+    #    hkl: PositionType = Query(..., example=(1, 0, 1)),
+    hkl: HklModel = Depends(),
     wavelength: float = Query(..., example=1.0),
     store: HklCalcStore = Depends(get_store),
     collection: Optional[str] = Query(default=None, example="B07"),

--- a/src/diffcalc_API/routes/ub.py
+++ b/src/diffcalc_API/routes/ub.py
@@ -1,4 +1,4 @@
-from typing import Optional, Tuple
+from typing import Optional
 
 from fastapi import APIRouter, Body, Depends, Query
 
@@ -11,6 +11,7 @@ from diffcalc_API.models.ub import (
     DeleteParams,
     EditOrientationParams,
     EditReflectionParams,
+    HklModel,
     SetLatticeParams,
 )
 from diffcalc_API.services import ub as service
@@ -152,7 +153,7 @@ async def set_lattice(
 async def modify_property(
     name: str,
     property: str,
-    target_value: Tuple[float, float, float] = Body(..., example=[1, 0, 0]),
+    target_value: HklModel = Body(..., example={"h": 1, "k": 0, "l": 0}),
     store: HklCalcStore = Depends(get_store),
     collection: Optional[str] = Query(default=None, example="B07"),
 ):

--- a/src/diffcalc_API/server.py
+++ b/src/diffcalc_API/server.py
@@ -46,7 +46,7 @@ async def server_exceptions_middleware(request: Request, call_next):
     try:
         return await call_next(request)
     except Exception as e:
-        # you probably want some kind of logging here
+        # TODO: implement proper logging
         tb = traceback.format_exc()
         print(tb)
 

--- a/src/diffcalc_API/server.py
+++ b/src/diffcalc_API/server.py
@@ -1,3 +1,4 @@
+import traceback
 from typing import Optional
 
 from diffcalc.util import DiffcalcException
@@ -46,6 +47,8 @@ async def server_exceptions_middleware(request: Request, call_next):
         return await call_next(request)
     except Exception as e:
         # you probably want some kind of logging here
+        tb = traceback.format_exc()
+        print(tb)
 
         return responses.JSONResponse(
             status_code=500,

--- a/src/diffcalc_API/services/constraints.py
+++ b/src/diffcalc_API/services/constraints.py
@@ -1,4 +1,4 @@
-from typing import Dict, Optional, Union
+from typing import Dict, Optional
 
 from diffcalc.hkl.constraints import Constraints
 
@@ -16,7 +16,7 @@ async def get_constraints(
 
 async def set_constraints(
     name: str,
-    constraints: Dict[str, Union[float, bool]],
+    constraints: Dict[str, float],
     store: HklCalcStore,
     collection: Optional[str],
 ) -> None:
@@ -52,7 +52,7 @@ async def remove_constraint(
 async def set_constraint(
     name: str,
     property: str,
-    value: Union[float, bool],
+    value: float,
     store: HklCalcStore,
     collection: Optional[str],
 ) -> None:

--- a/src/diffcalc_API/services/hkl.py
+++ b/src/diffcalc_API/services/hkl.py
@@ -140,14 +140,19 @@ def combine_lab_position_results(
 
 async def calculate_ub(
     name: str,
-    first_tag: Optional[Union[int, str]],
-    second_tag: Optional[Union[int, str]],
     store: HklCalcStore,
     collection: Optional[str],
+    tag1: Optional[str],
+    idx1: Optional[int],
+    tag2: Optional[str],
+    idx2: Optional[int],
 ) -> List[List[float]]:
     hklcalc = await store.load(name, collection)
 
-    hklcalc.ubcalc.calc_ub(first_tag, second_tag)
+    first_retrieve: Optional[Union[str, int]] = tag1 if tag1 else idx1
+    second_retrieve: Optional[Union[str, int]] = tag2 if tag2 else idx2
+
+    hklcalc.ubcalc.calc_ub(first_retrieve, second_retrieve)
 
     await store.save(name, hklcalc, collection)
     return np.round(hklcalc.ubcalc.UB, 6).tolist()

--- a/src/diffcalc_API/services/ub.py
+++ b/src/diffcalc_API/services/ub.py
@@ -46,21 +46,31 @@ async def edit_reflection(
 ) -> None:
     hklcalc = await store.load(name, collection)
 
-    try:
-        reflection = hklcalc.ubcalc.get_reflection(params.tag_or_idx)
-    except (IndexError, ValueError):
-        raise ReferenceRetrievalError(params.tag_or_idx, "reflection")
-
-    # TODO: make this more readable...
-    hklcalc.ubcalc.edit_reflection(
-        params.tag_or_idx,
-        tuple(params.hkl.dict().values())
-        if params.hkl
-        else (reflection.h, reflection.k, reflection.l),
-        Position(params.position.dict()) if params.position else reflection.pos,
-        params.energy if params.energy else reflection.energy,
-        params.tag_or_idx if isinstance(params.tag_or_idx, str) else None,
+    retrieve: Optional[Union[int, str]] = (
+        params.retrieve_idx if params.retrieve_idx is not None else params.retrieve_tag
     )
+
+    try:
+        reflection = hklcalc.ubcalc.get_reflection(retrieve)
+    except (IndexError, ValueError):
+        raise ReferenceRetrievalError(retrieve, "reflection")
+
+    inputs = {
+        "idx": retrieve,
+        "hkl": (reflection.h, reflection.k, reflection.l),
+        "position": reflection.pos,
+        "energy": reflection.energy,
+        "tag": params.set_tag,
+    }
+
+    if params.hkl:
+        inputs["hkl"] = tuple(params.hkl.dict().values())
+    if params.position:
+        inputs["position"] = Position(**params.position.dict())
+    if params.energy:
+        inputs["energy"] = params.energy
+
+    hklcalc.ubcalc.edit_reflection(**inputs)
 
     await store.save(name, hklcalc, collection)
 
@@ -110,22 +120,30 @@ async def edit_orientation(
 ) -> None:
     hklcalc = await store.load(name, collection)
 
-    try:
-        orientation = hklcalc.ubcalc.get_orientation(params.tag_or_idx)
-    except (IndexError, ValueError):
-        raise ReferenceRetrievalError(params.tag_or_idx, "orientation")
-
-    hklcalc.ubcalc.edit_orientation(
-        params.tag_or_idx,
-        tuple(params.hkl.dict().values())
-        if params.hkl
-        else (orientation.h, orientation.k, orientation.l),
-        tuple(params.xyz.dict().values())
-        if params.xyz
-        else (orientation.x, orientation.y, orientation.z),
-        Position(params.position.dict()) if params.position else orientation.pos,
-        params.tag_or_idx if isinstance(params.tag_or_idx, str) else None,
+    retrieve: Optional[Union[int, str]] = (
+        params.retrieve_idx if params.retrieve_idx is not None else params.retrieve_tag
     )
+    try:
+        orientation = hklcalc.ubcalc.get_orientation(retrieve)
+    except (IndexError, ValueError):
+        raise ReferenceRetrievalError(retrieve, "reflection")
+
+    inputs = {
+        "idx": retrieve,
+        "hkl": (orientation.h, orientation.k, orientation.l),
+        "xyz": (orientation.x, orientation.y, orientation.z),
+        "position": orientation.pos,
+        "tag": params.set_tag,
+    }
+
+    if params.hkl:
+        inputs["hkl"] = tuple(params.hkl.dict().values())
+    if params.xyz:
+        inputs["xyz"] = tuple(params.xyz.dict().values())
+    if params.position:
+        inputs["position"] = Position(**params.position.dict())
+
+    hklcalc.ubcalc.edit_orientation(**inputs)
 
     await store.save(name, hklcalc, collection)
 

--- a/src/diffcalc_API/services/ub.py
+++ b/src/diffcalc_API/services/ub.py
@@ -50,7 +50,7 @@ async def edit_reflection(
     hklcalc = await store.load(name, collection)
 
     retrieve: Union[int, str] = (
-        idx if idx is not None else (tag if tag is not None else 0)
+        tag if tag is not None else (idx if idx is not None else 0)
     )
 
     try:
@@ -132,7 +132,7 @@ async def edit_orientation(
     hklcalc = await store.load(name, collection)
 
     retrieve: Union[int, str] = (
-        idx if idx is not None else (tag if tag is not None else 0)
+        tag if tag is not None else (idx if idx is not None else 0)
     )
 
     try:
@@ -169,7 +169,9 @@ async def delete_orientation(
 ) -> None:
     hklcalc = await store.load(name, collection)
 
-    retrieve: Optional[Union[int, str]] = idx if idx is not None else tag
+    retrieve: Union[int, str] = (
+        tag if tag is not None else (idx if idx is not None else 0)
+    )
 
     try:
         hklcalc.ubcalc.get_orientation(retrieve)

--- a/tests/test_hklcalc.py
+++ b/tests/test_hklcalc.py
@@ -192,8 +192,6 @@ def test_calc_ub(client: TestClient):
 
 
 def test_calc_ub_fails_when_incorrect_tags(client: TestClient):
-    response = client.get(
-        "/hkl/test/UB", params={"first_tag": "one", "second_tag": "two"}
-    )
+    response = client.get("/hkl/test/UB", params={"tag1": "one", "idx2": 2})
 
     assert response.status_code == 400

--- a/tests/test_ubcalc.py
+++ b/tests/test_ubcalc.py
@@ -55,8 +55,8 @@ def test_add_reflection(client: TestClient):
     response = client.post(
         "/ub/test/reflection",
         json={
-            "hkl": [0, 0, 1],
-            "position": [7, 0, 10, 0, 0, 0],
+            "hkl": {"h": 0, "k": 0, "l": 1},
+            "position": {"mu": 7, "delta": 0, "nu": 10, "eta": 0, "chi": 0, "phi": 0},
             "energy": 12,
             "tag": "foo",
         },
@@ -117,8 +117,8 @@ def test_add_orientation(client: TestClient):
     response = client.post(
         "/ub/test/orientation",
         json={
-            "hkl": [0, 1, 0],
-            "xyz": [0, 1, 0],
+            "hkl": {"h": 0, "k": 1, "l": 0},
+            "xyz": {"x": 0, "y": 1, "z": 0},
             "tag": "bar",
         },
     )
@@ -134,7 +134,7 @@ def test_edit_orientation(client: TestClient):
     response = client.put(
         "/ub/test/orientation",
         json={
-            "xyz": [1, 1, 0],
+            "xyz": {"x": 1, "y": 1, "z": 0},
             "tag_or_idx": "bar",
         },
     )
@@ -167,7 +167,7 @@ def test_edit_or_delete_orientation_fails_for_non_existing_orientation(
     edit_response = client.put(
         "/ub/test/orientation",
         json={
-            "xyz": [1, 1, 0],
+            "xyz": {"x": 1, "y": 1, "z": 0},
             "tag_or_idx": "bar",
         },
     )
@@ -210,7 +210,7 @@ def test_set_lattice_fails_for_empty_data(client: TestClient):
 def test_modify_property(client: TestClient):
     response = client.put(
         "/ub/test/n_hkl",
-        json=[0, 0, 1],
+        json={"h": 0, "k": 0, "l": 1},
     )
 
     assert response.status_code == 200
@@ -220,6 +220,6 @@ def test_modify_property(client: TestClient):
 def test_modify_non_existent_property(client: TestClient):
     response = client.put(
         "/ub/test/silly_property",
-        json=[0, 0, 1],
+        json={"h": 0, "k": 0, "l": 1},
     )
     assert response.status_code == ErrorCodes.INVALID_PROPERTY

--- a/tests/test_ubcalc.py
+++ b/tests/test_ubcalc.py
@@ -53,12 +53,11 @@ def test_get_ub(client: TestClient):
 
 def test_add_reflection(client: TestClient):
     response = client.post(
-        "/ub/test/reflection",
+        "/ub/test/reflection?tag=foo",
         json={
             "hkl": {"h": 0, "k": 0, "l": 1},
             "position": {"mu": 7, "delta": 0, "nu": 10, "eta": 0, "chi": 0, "phi": 0},
             "energy": 12,
-            "tag": "foo",
         },
     )
 
@@ -71,8 +70,8 @@ def test_add_reflection(client: TestClient):
 def test_edit_reflection(client: TestClient):
     dummy_hkl.ubcalc.add_reflection([0, 0, 1], Position(7, 0, 10, 0, 0, 0), 12, "foo")
     response = client.put(
-        "/ub/test/reflection",
-        json={"energy": 13, "retrieve_tag": "foo", "set_tag": "bar"},
+        "/ub/test/reflection?tag=foo",
+        json={"energy": 13, "set_tag": "bar"},
     )
     reflection = dummy_hkl.ubcalc.get_reflection("bar")
 
@@ -80,8 +79,8 @@ def test_edit_reflection(client: TestClient):
     assert reflection.energy == 13
 
     response_idx = client.put(
-        "/ub/test/reflection",
-        json={"hkl": {"h": 0, "k": 3, "l": 1}, "retrieve_idx": 0},
+        "/ub/test/reflection?idx=0",
+        json={"hkl": {"h": 0, "k": 3, "l": 1}},
     )
 
     assert response_idx.status_code == 200
@@ -89,7 +88,7 @@ def test_edit_reflection(client: TestClient):
 
     assert reflection_idx.h == 0
     assert reflection_idx.k == 3
-    assert reflection_idx.tag is None
+    assert reflection_idx.tag == "bar"
 
     dummy_hkl.ubcalc.del_reflection(0)
 
@@ -107,11 +106,8 @@ def test_edit_or_delete_reflection_fails_for_non_existing_reflection(
     client: TestClient,
 ):
     edit_response = client.put(
-        "/ub/test/reflection",
-        json={
-            "energy": 13,
-            "retrieve_tag": "foo",
-        },
+        "/ub/test/reflection?tag=foo",
+        json={"energy": 13},
     )
     delete_response = client.delete("/ub/test/reflection?tag=foo")
 
@@ -121,11 +117,10 @@ def test_edit_or_delete_reflection_fails_for_non_existing_reflection(
 
 def test_add_orientation(client: TestClient):
     response = client.post(
-        "/ub/test/orientation",
+        "/ub/test/orientation?tag=bar",
         json={
             "hkl": {"h": 0, "k": 1, "l": 0},
             "xyz": {"x": 0, "y": 1, "z": 0},
-            "tag": "bar",
         },
     )
 
@@ -138,8 +133,8 @@ def test_add_orientation(client: TestClient):
 def test_edit_orientation(client: TestClient):
     dummy_hkl.ubcalc.add_orientation([0, 0, 1], [0, 0, 1], None, "bar")
     response = client.put(
-        "/ub/test/orientation",
-        json={"xyz": {"x": 1, "y": 1, "z": 0}, "retrieve_tag": "bar", "set_tag": "bar"},
+        "/ub/test/orientation?tag=bar",
+        json={"xyz": {"x": 1, "y": 1, "z": 0}, "set_tag": "bar"},
     )
     orientation = dummy_hkl.ubcalc.get_orientation("bar")
 
@@ -165,8 +160,8 @@ def test_edit_or_delete_orientation_fails_for_non_existing_orientation(
     client: TestClient,
 ):
     edit_response = client.put(
-        "/ub/test/orientation",
-        json={"xyz": {"x": 1, "y": 1, "z": 0}, "retrieve_tag": "bar", "set_tag": "bar"},
+        "/ub/test/orientation?tag=bar",
+        json={"xyz": {"x": 1, "y": 1, "z": 0}},
     )
     delete_response = client.delete(
         "/ub/test/orientation?tag=bar",


### PR DESCRIPTION
This PR addresses two related issues:

1. Delete requests have a request body (which they shouldn't)
2. confusing union types in parameters

For the first task, the request body used to have a 'tag_or_idx' parameter which was a union of int or str. Now, I've changed my delete paths to require at least one query parameter, tag or idx. That is /a/path?tag=foo or /a/path?idx=0, which will dictate what is deleted.

Then, I decided to decouple my tag_or_idx parameters in general, mostly in the parameters of request bodies. As a result, my pydantic models for editing orientations/reflections now have separate 'tag' and 'idx' fields.

However, I have one major question about this change - is it best to include these 'tag' and 'idx' fields, which are currently in my EditOrientationParams and EditReflectionParams pydantic models for the request body, to be query parameters? This would be more in line with the new style for deleting orientations/reflections, however to me it also makes more sense for everything to be neatly bundled in the request body where appropriate.