### PR TITLE
feature: make set_lattice call accept a lattice name

### DIFF
--- a/src/diffcalc_API/models/ub.py
+++ b/src/diffcalc_API/models/ub.py
@@ -25,6 +25,7 @@ class PositionModel(BaseModel):
 
 
 class SetLatticeParams(BaseModel):
+    name: Optional[str] = None
     system: Optional[str] = None
     a: Optional[float] = None
     b: Optional[float] = None

--- a/src/diffcalc_API/services/ub.py
+++ b/src/diffcalc_API/services/ub.py
@@ -188,7 +188,11 @@ async def set_lattice(
 ) -> None:
     hklcalc = await store.load(name, collection)
 
-    hklcalc.ubcalc.set_lattice(name=name, **params.dict())
+    input_params = params.dict()
+    crystal_name = name if not params.name else params.name
+    input_params.pop("name")
+
+    hklcalc.ubcalc.set_lattice(name=crystal_name, **input_params)
 
     await store.save(name, hklcalc, collection)
 


### PR DESCRIPTION
added name to setLatticeParams so that a crystal name can be set with the lattice. By default, if not provided, the name of the hkl object is used instead.

Currently, the lattice name is immediately set to the same name as the hkl object. This isn't always useful or the functionality users will want. This PR attempts to resolve that.