### PR TITLE
Change scan models

### DIFF
--- a/src/diffcalc_API/models/response.py
+++ b/src/diffcalc_API/models/response.py
@@ -30,10 +30,16 @@ class ArrayResponse(BaseModel):
     payload: List[List[float]]
 
 
-class ScanResponse(BaseModel):
-    """Used for all scans in hkl endpoints."""
+class SimpleScanResponse(BaseModel):
+    """Used for scans in hkl endpoints across one float parameter, e.g. wavelength."""
 
-    payload: Dict[str, List[Dict[str, float]]]
+    payload: Dict[float, List[Dict[str, float]]]
+
+
+class HklScanResponse(BaseModel):
+    """Used for scans in hkl endpoints across miller indices."""
+
+    payload: Dict[HklModel, List[Dict[str, float]]]
 
 
 class DiffractorAnglesResponse(BaseModel):

--- a/src/diffcalc_API/models/ub.py
+++ b/src/diffcalc_API/models/ub.py
@@ -12,6 +12,12 @@ class HklModel(BaseModel):
     k: float
     l: float
 
+    def __eq__(self, other):
+        return self.h == other.h and self.k == other.k and self.l == other.l
+
+    def __hash__(self):
+        return hash((self.h, self.k, self.l))
+
 
 class XyzModel(BaseModel):
     """Model containing real space positions."""

--- a/src/diffcalc_API/models/ub.py
+++ b/src/diffcalc_API/models/ub.py
@@ -13,7 +13,9 @@ class HklModel(BaseModel):
     l: float
 
     def __eq__(self, other):
-        return self.h == other.h and self.k == other.k and self.l == other.l
+        return (
+            self.h == other.h and self.k == other.k and self.l == other.l
+        )  # noqa: E741
 
     def __hash__(self):
         return hash((self.h, self.k, self.l))

--- a/src/diffcalc_API/routes/hkl.py
+++ b/src/diffcalc_API/routes/hkl.py
@@ -200,8 +200,8 @@ async def scan_wavelength(
         collection: collection within which the hkl object resides.
 
     Returns:
-        SimpleScanResponse containing a dictionary of each wavelength and the corresponding
-        possible diffractometer positions.
+        SimpleScanResponse containing a dictionary of each wavelength and the
+        corresponding possible diffractometer positions.
     """
     solution_constraints = SolutionConstraints(axes, low_bound, high_bound)
     if not solution_constraints.valid:

--- a/src/diffcalc_API/services/hkl.py
+++ b/src/diffcalc_API/services/hkl.py
@@ -77,7 +77,7 @@ async def scan_hkl(
     solution_constraints: SolutionConstraints,
     store: HklCalcStore,
     collection: Optional[str],
-) -> Dict[str, List[Dict[str, float]]]:
+) -> Dict[HklModel, List[Dict[str, float]]]:
     """Retrieve possible diffractometer positions for a range of miller indices.
 
     Args:
@@ -114,10 +114,9 @@ async def scan_hkl(
                 "choose a hkl range that does not cross through [0, 0, 0]"
             )  # is this good enough? do people need scans through 0,0,0?
 
+        hkl = HklModel(h=h, k=k, l=l)
         all_positions = hklcalc.get_position(h, k, l, wavelength)
-        results[f"({h}, {k}, {l})"] = combine_lab_position_results(
-            all_positions, solution_constraints
-        )
+        results[hkl] = combine_lab_position_results(all_positions, solution_constraints)
 
     return results
 
@@ -131,7 +130,7 @@ async def scan_wavelength(
     solution_constraints: SolutionConstraints,
     store: HklCalcStore,
     collection: Optional[str],
-) -> Dict[str, List[Dict[str, float]]]:
+) -> Dict[float, List[Dict[str, float]]]:
     """Retrieve possible diffractometer positions for a range of wavelengths.
 
     Args:
@@ -158,7 +157,7 @@ async def scan_wavelength(
 
     for wavelength in wavelengths:
         all_positions = hklcalc.get_position(*hkl.dict().values(), wavelength)
-        result[f"{wavelength}"] = combine_lab_position_results(
+        result[wavelength] = combine_lab_position_results(
             all_positions, solution_constraints
         )
 
@@ -176,7 +175,7 @@ async def scan_constraint(
     solution_constraints: SolutionConstraints,
     store: HklCalcStore,
     collection: Optional[str],
-) -> Dict[str, List[Dict[str, float]]]:
+) -> Dict[float, List[Dict[str, float]]]:
     """Retrieve possible diffractometer positions while scanning across a constraint.
 
     Args:
@@ -204,7 +203,7 @@ async def scan_constraint(
     for value in np.arange(start, stop + inc, inc):
         setattr(hklcalc, constraint, value)
         all_positions = hklcalc.get_position(*hkl.dict().values(), wavelength)
-        result[f"{value}"] = combine_lab_position_results(
+        result[value] = combine_lab_position_results(
             all_positions, solution_constraints
         )
 


### PR DESCRIPTION
PR to modify scan models. 

Currently, scans return a response model with a payload of a dictionary of strings and a list of another dictionary. This is fine, except for the Java client makes it awkward to extract the data. This PR is meant to make this process easier, by changing this response type to a dictionary of float (and a list of another dictionary) or a dictionary of HklModel. In other words, by being more prescriptive about the return type, I need to do less work with the Java client on the other end.