### PR TITLE
Add more get routes

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -30,6 +30,7 @@ install_requires =
     pymongo
     motor
     requests
+    httpx
 
 [options.extras_require]
 # For development tests/docs

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,7 +30,6 @@ install_requires =
     pymongo
     motor
     requests
-    httpx
 
 [options.extras_require]
 # For development tests/docs
@@ -47,6 +46,7 @@ dev =
     mock
     pydocstyle
     mongomock
+    httpx
 
 [options.packages.find]
 where = src

--- a/src/diffcalc_api/config.py
+++ b/src/diffcalc_api/config.py
@@ -40,7 +40,6 @@ except ValueError:
     )
 
 SAVE_PICKLES_FOLDER = "/"
-VECTOR_PROPERTIES = ["n_hkl", "n_phi", "surf_nhkl", "surf_nphi"]
 CONSTRAINTS_WITH_NO_VALUE = {"a_eq_b", "bin_eq_bout", "mu_is_gam", "bisect"}
 
 

--- a/src/diffcalc_api/errors/ub.py
+++ b/src/diffcalc_api/errors/ub.py
@@ -4,7 +4,6 @@ from typing import Optional, Union
 
 import numpy as np
 
-from diffcalc_api.config import VECTOR_PROPERTIES
 from diffcalc_api.errors.definitions import (
     ALL_RESPONSES,
     DiffcalcAPIException,
@@ -17,7 +16,6 @@ class ErrorCodes(ErrorCodesBase):
 
     INVALID_SET_LATTICE_PARAMS = 400
     REFERENCE_RETRIEVAL_ERROR = 403
-    INVALID_PROPERTY = 400
     NO_TAG_OR_IDX_PROVIDED = 400
     BOTH_TAG_OR_IDX_PROVIDED = 400
     NO_UB_MATRIX_ERROR = 400
@@ -83,15 +81,6 @@ class ReferenceRetrievalError(DiffcalcAPIException):
         """Set detail and status code."""
         self.detail = f"cannot retrieve {reference_type} with tag or index {handle}"
         self.status_code = ErrorCodes.REFERENCE_RETRIEVAL_ERROR
-
-
-class InvalidPropertyError(DiffcalcAPIException):
-    """Error that gets thrown if attempting to modify a non-existing property."""
-
-    def __init__(self):
-        """Set detail and status code."""
-        self.detail = f"invalid property. Choose one of: {VECTOR_PROPERTIES}"
-        self.status_code = ErrorCodes.INVALID_PROPERTY
 
 
 class NoUbMatrixError(DiffcalcAPIException):

--- a/src/diffcalc_api/errors/ub.py
+++ b/src/diffcalc_api/errors/ub.py
@@ -97,11 +97,15 @@ class InvalidPropertyError(DiffcalcAPIException):
 class NoUbMatrixError(DiffcalcAPIException):
     """When there is no U/UB matrix, some commands in diffcalc-core fail."""
 
-    def __init__(self):
+    def __init__(self, message: Optional[str] = None):
         """Set detail and status code."""
         self.detail = (
-            "It seems like there is no UB matrix for this record. Please "
-            + "try again after setting the UB matrix, either by calculating the UB from"
-            + " existing reflections/orientations or setting it explicitly."
+            (
+                "It seems like there is no UB matrix for this record. Please "
+                + "try again after setting the UB matrix, either by calculating the UB"
+                + " from existing reflections/orientations or setting it explicitly."
+            )
+            if message is None
+            else message
         )
         self.status_code = ErrorCodes.NO_UB_MATRIX_ERROR

--- a/src/diffcalc_api/routes/ub.py
+++ b/src/diffcalc_api/routes/ub.py
@@ -36,26 +36,6 @@ from diffcalc_api.stores.protocol import HklCalcStore, get_store
 router = APIRouter(prefix="/ub", tags=["ub"])
 
 
-@router.get("/{name}", response_model=StringResponse)
-async def get_ub(
-    name: str,
-    store: HklCalcStore = Depends(get_store),
-    collection: Optional[str] = Query(default=None, example="B07"),
-):
-    """Get the status of the UB object in the hkl object.
-
-    Args:
-        name: the name of the hkl object to access within the store
-        store: accessor to the hkl object
-        collection: collection within which the hkl object resides
-
-    Returns:
-        a string with the current state of the UB object
-    """
-    content = await service.get_ub(name, store, collection)
-    return StringResponse(payload=content)
-
-
 @router.post("/{name}/reflection", response_model=InfoResponse)
 async def add_reflection(
     name: str,
@@ -357,7 +337,7 @@ async def get_miscut_from_hkl(
     )
 
 
-@router.get("/{name}/ub", response_model=ArrayResponse)
+@router.get("/{name}/calculate/ub", response_model=ArrayResponse)
 async def calculate_ub(
     name: str,
     tag1: Optional[str] = Query(default=None, example="refl1"),
@@ -437,6 +417,68 @@ async def set_u(
     return InfoResponse(
         message=f"U matrix set for crystal {name} of collection {collection}"
     )
+
+
+@router.get("/{name}/ub", response_model=ArrayResponse)
+async def get_ub(
+    name: str,
+    store: HklCalcStore = Depends(get_store),
+    collection: Optional[str] = Query(default=None, example="B07"),
+):
+    """Get the UB matrix.
+
+    Args:
+        name: the name of the hkl object to access within the store
+        store: accessor to the hkl object.
+        collection: collection within which the hkl object resides.
+
+    Returns:
+        ArrayResponse object with the UB matrix as an array.
+
+    """
+    content = await service.get_ub(name, store, collection)
+    return ArrayResponse(payload=content)
+
+
+@router.get("/{name}/u", response_model=ArrayResponse)
+async def get_u(
+    name: str,
+    store: HklCalcStore = Depends(get_store),
+    collection: Optional[str] = Query(default=None, example="B07"),
+):
+    """Get the U matrix.
+
+    Args:
+        name: the name of the hkl object to access within the store
+        store: accessor to the hkl object.
+        collection: collection within which the hkl object resides.
+
+    Returns:
+        ArrayResponse object with the U matrix as an array.
+
+    """
+    content = await service.get_u(name, store, collection)
+    return ArrayResponse(payload=content)
+
+
+@router.get("/{name}/status/ub", response_model=StringResponse)
+async def get_ub_status(
+    name: str,
+    store: HklCalcStore = Depends(get_store),
+    collection: Optional[str] = Query(default=None, example="B07"),
+):
+    """Get the status of the UB object in the hkl object.
+
+    Args:
+        name: the name of the hkl object to access within the store
+        store: accessor to the hkl object
+        collection: collection within which the hkl object resides
+
+    Returns:
+        a string with the current state of the UB object
+    """
+    content = await service.get_ub_status(name, store, collection)
+    return StringResponse(payload=content)
 
 
 @router.put("/{name}/{property}", response_model=InfoResponse)

--- a/src/diffcalc_api/routes/ub.py
+++ b/src/diffcalc_api/routes/ub.py
@@ -4,8 +4,7 @@ from typing import List, Optional, Union
 
 from fastapi import APIRouter, Body, Depends, Query
 
-# from diffcalc_api.config import VECTOR_PROPERTIES
-from diffcalc_api.errors.ub import (  # InvalidPropertyError,
+from diffcalc_api.errors.ub import (
     BothTagAndIdxProvidedError,
     InvalidSetLatticeParamsError,
     NoTagOrIdxProvidedError,

--- a/src/diffcalc_api/routes/ub.py
+++ b/src/diffcalc_api/routes/ub.py
@@ -337,7 +337,7 @@ async def get_miscut_from_hkl(
     )
 
 
-@router.get("/{name}/calculate/ub", response_model=ArrayResponse)
+@router.get("/{name}/calculate", response_model=ArrayResponse)
 async def calculate_ub(
     name: str,
     tag1: Optional[str] = Query(default=None, example="refl1"),
@@ -461,7 +461,7 @@ async def get_u(
     return ArrayResponse(payload=content)
 
 
-@router.get("/{name}/status/ub", response_model=StringResponse)
+@router.get("/{name}/status", response_model=StringResponse)
 async def get_ub_status(
     name: str,
     store: HklCalcStore = Depends(get_store),

--- a/src/diffcalc_api/services/ub.py
+++ b/src/diffcalc_api/services/ub.py
@@ -20,7 +20,9 @@ from diffcalc_api.models.ub import (
 from diffcalc_api.stores.protocol import HklCalcStore
 
 
-async def get_ub(name: str, store: HklCalcStore, collection: Optional[str]) -> str:
+async def get_ub_status(
+    name: str, store: HklCalcStore, collection: Optional[str]
+) -> str:
     """Get the status of the UB object in the hkl object.
 
     Args:
@@ -34,6 +36,54 @@ async def get_ub(name: str, store: HklCalcStore, collection: Optional[str]) -> s
     hklcalc = await store.load(name, collection)
 
     return str(hklcalc.ubcalc)
+
+
+async def get_ub(
+    name: str, store: HklCalcStore, collection: Optional[str]
+) -> List[List[float]]:
+    """Get the status of the UB object in the hkl object.
+
+    Args:
+        name: the name of the hkl object to access within the store
+        store: accessor to the hkl object
+        collection: collection within which the hkl object resides
+
+    Returns:
+        a string with the current state of the UB object
+    """
+    hklcalc = await store.load(name, collection)
+    ubcalc: UBCalculation = hklcalc.ubcalc
+
+    if ubcalc.UB is not None:
+        return ubcalc.UB.tolist()
+    else:
+        raise NoUbMatrixError(
+            "Cannot retrieve UB matrix. Are you sure it's been set/calculated?"
+        )
+
+
+async def get_u(
+    name: str, store: HklCalcStore, collection: Optional[str]
+) -> List[List[float]]:
+    """Get the status of the UB object in the hkl object.
+
+    Args:
+        name: the name of the hkl object to access within the store
+        store: accessor to the hkl object
+        collection: collection within which the hkl object resides
+
+    Returns:
+        a string with the current state of the UB object
+    """
+    hklcalc = await store.load(name, collection)
+    ubcalc: UBCalculation = hklcalc.ubcalc
+
+    if ubcalc.U is not None:
+        return ubcalc.U.tolist()
+    else:
+        raise NoUbMatrixError(
+            "Cannot retrieve U matrix. Are you sure it's been set/calculated?"
+        )
 
 
 async def add_reflection(

--- a/src/diffcalc_api/services/ub.py
+++ b/src/diffcalc_api/services/ub.py
@@ -38,52 +38,9 @@ async def get_ub_status(
     return str(hklcalc.ubcalc)
 
 
-async def get_ub(
-    name: str, store: HklCalcStore, collection: Optional[str]
-) -> List[List[float]]:
-    """Get the status of the UB object in the hkl object.
-
-    Args:
-        name: the name of the hkl object to access within the store
-        store: accessor to the hkl object
-        collection: collection within which the hkl object resides
-
-    Returns:
-        a string with the current state of the UB object
-    """
-    hklcalc = await store.load(name, collection)
-    ubcalc: UBCalculation = hklcalc.ubcalc
-
-    if ubcalc.UB is not None:
-        return ubcalc.UB.tolist()
-    else:
-        raise NoUbMatrixError(
-            "Cannot retrieve UB matrix. Are you sure it's been set/calculated?"
-        )
-
-
-async def get_u(
-    name: str, store: HklCalcStore, collection: Optional[str]
-) -> List[List[float]]:
-    """Get the status of the UB object in the hkl object.
-
-    Args:
-        name: the name of the hkl object to access within the store
-        store: accessor to the hkl object
-        collection: collection within which the hkl object resides
-
-    Returns:
-        a string with the current state of the UB object
-    """
-    hklcalc = await store.load(name, collection)
-    ubcalc: UBCalculation = hklcalc.ubcalc
-
-    if ubcalc.U is not None:
-        return ubcalc.U.tolist()
-    else:
-        raise NoUbMatrixError(
-            "Cannot retrieve U matrix. Are you sure it's been set/calculated?"
-        )
+#######################################################################################
+#                                     Reflections                                     #
+#######################################################################################
 
 
 async def add_reflection(
@@ -198,6 +155,11 @@ async def delete_reflection(
     hklcalc.ubcalc.del_reflection(retrieve)
 
     await store.save(name, hklcalc, collection)
+
+
+#######################################################################################
+#                                    Orientations                                     #
+#######################################################################################
 
 
 async def add_orientation(
@@ -315,6 +277,11 @@ async def delete_orientation(
     await store.save(name, hklcalc, collection)
 
 
+#######################################################################################
+#                                       Crystal                                       #
+#######################################################################################
+
+
 async def set_lattice(
     name: str, params: SetLatticeParams, store: HklCalcStore, collection: Optional[str]
 ) -> None:
@@ -338,29 +305,9 @@ async def set_lattice(
     await store.save(name, hklcalc, collection)
 
 
-async def modify_property(
-    name: str,
-    property: str,
-    target_value: HklModel,
-    store: HklCalcStore,
-    collection: Optional[str],
-) -> None:
-    """Set a property of the UB object in a given hkl object.
-
-    Args:
-        name: the name of the hkl object to access within the store
-        property: the property of the UB object to set
-        target_value: the miller indices to set them to
-        store: accessor to the hkl object
-        collection: collection within which the hkl object resides
-
-    The property to be set must be a valid vector property.
-    """
-    hklcalc = await store.load(name, collection)
-
-    setattr(hklcalc.ubcalc, property, tuple(target_value.dict().values()))
-
-    await store.save(name, hklcalc, collection)
+#######################################################################################
+#                                       Miscuts                                       #
+#######################################################################################
 
 
 async def set_miscut(
@@ -447,6 +394,11 @@ async def get_miscut_from_hkl(
     return angle, axis
 
 
+#######################################################################################
+#                                    U/UB Matrices                                    #
+#######################################################################################
+
+
 async def calculate_ub(
     name: str,
     store: HklCalcStore,
@@ -484,6 +436,54 @@ async def calculate_ub(
 
     await store.save(name, hklcalc, collection)
     return np.round(hklcalc.ubcalc.UB, 6).tolist()
+
+
+async def get_ub(
+    name: str, store: HklCalcStore, collection: Optional[str]
+) -> List[List[float]]:
+    """Get the status of the UB object in the hkl object.
+
+    Args:
+        name: the name of the hkl object to access within the store
+        store: accessor to the hkl object
+        collection: collection within which the hkl object resides
+
+    Returns:
+        a string with the current state of the UB object
+    """
+    hklcalc = await store.load(name, collection)
+    ubcalc: UBCalculation = hklcalc.ubcalc
+
+    if ubcalc.UB is not None:
+        return ubcalc.UB.tolist()
+    else:
+        raise NoUbMatrixError(
+            "Cannot retrieve UB matrix. Are you sure it's been set/calculated?"
+        )
+
+
+async def get_u(
+    name: str, store: HklCalcStore, collection: Optional[str]
+) -> List[List[float]]:
+    """Get the status of the UB object in the hkl object.
+
+    Args:
+        name: the name of the hkl object to access within the store
+        store: accessor to the hkl object
+        collection: collection within which the hkl object resides
+
+    Returns:
+        a string with the current state of the UB object
+    """
+    hklcalc = await store.load(name, collection)
+    ubcalc: UBCalculation = hklcalc.ubcalc
+
+    if ubcalc.U is not None:
+        return ubcalc.U.tolist()
+    else:
+        raise NoUbMatrixError(
+            "Cannot retrieve U matrix. Are you sure it's been set/calculated?"
+        )
 
 
 async def set_u(
@@ -528,3 +528,202 @@ async def set_ub(
     ubcalc.set_ub(ub_matrix)
 
     await store.save(name, hklcalc, collection)
+
+
+#######################################################################################
+#                            Surface and Reference Vectors                            #
+#######################################################################################
+
+
+async def set_lab_reference_vector(
+    name: str,
+    target_value: XyzModel,
+    store: HklCalcStore,
+    collection: Optional[str],
+) -> None:
+    """Set the lab reference vector n_phi.
+
+    Args:
+        name: the name of the hkl object to access within the store
+        target_value: the vector positon in real space
+        store: accessor to the hkl object.
+        collection: collection within which the hkl object resides.
+
+    Returns:
+        None
+
+    """
+    hklcalc = await store.load(name, collection)
+
+    ubcalc: UBCalculation = hklcalc.ubcalc
+    ubcalc.n_phi = (target_value.x, target_value.y, target_value.z)
+
+    await store.save(name, hklcalc, collection)
+
+
+async def set_miller_reference_vector(
+    name: str,
+    target_value: HklModel,
+    store: HklCalcStore,
+    collection: Optional[str],
+) -> None:
+    """Set the reference vector n_hkl.
+
+    Args:
+        name: the name of the hkl object to access within the store
+        target_value: the vector positon in reciprocal space
+        store: accessor to the hkl object.
+        collection: collection within which the hkl object resides.
+
+    Returns:
+        None
+
+    """
+    hklcalc = await store.load(name, collection)
+
+    ubcalc: UBCalculation = hklcalc.ubcalc
+    ubcalc.n_hkl = (target_value.h, target_value.k, target_value.l)
+
+    await store.save(name, hklcalc, collection)
+
+
+async def set_lab_surface_normal(
+    name: str,
+    target_value: XyzModel,
+    store: HklCalcStore,
+    collection: Optional[str],
+):
+    """Set the reference vector surf_nphi.
+
+    Args:
+        name: the name of the hkl object to access within the store
+        target_value: the vector positon in real space
+        store: accessor to the hkl object.
+        collection: collection within which the hkl object resides.
+
+    Returns:
+        None
+
+    """
+    hklcalc = await store.load(name, collection)
+
+    ubcalc: UBCalculation = hklcalc.ubcalc
+    ubcalc.surf_nphi = (target_value.x, target_value.y, target_value.z)
+
+    await store.save(name, hklcalc, collection)
+
+
+async def set_miller_surface_normal(
+    name: str,
+    target_value: HklModel,
+    store: HklCalcStore,
+    collection: Optional[str],
+):
+    """Set the reference vector surf_nhkl.
+
+    Args:
+        name: the name of the hkl object to access within the store
+        target_value: the vector positon in reciprocal space
+        store: accessor to the hkl object.
+        collection: collection within which the hkl object resides.
+
+    Returns:
+        None
+
+    """
+    hklcalc = await store.load(name, collection)
+
+    ubcalc: UBCalculation = hklcalc.ubcalc
+    ubcalc.surf_nhkl = (target_value.h, target_value.k, target_value.l)
+
+    await store.save(name, hklcalc, collection)
+
+
+async def get_lab_reference_vector(
+    name: str, store: HklCalcStore, collection: Optional[str]
+) -> Optional[List[List[float]]]:
+    """Get the reference vector nphi.
+
+    Args:
+        name: the name of the hkl object to access within the store
+        store: accessor to the hkl object.
+        collection: collection within which the hkl object resides.
+
+    Returns:
+        Column vector in List[List[float]] format, or None
+
+    """
+    hklcalc = await store.load(name, collection)
+    ubcalc: UBCalculation = hklcalc.ubcalc
+
+    n_phi = ubcalc.n_phi
+    return n_phi.tolist() if n_phi is not None else None
+
+
+async def get_miller_reference_vector(
+    name: str,
+    store: HklCalcStore,
+    collection,
+) -> Optional[List[List[float]]]:
+    """Get the reference vector nhkl.
+
+    Args:
+        name: the name of the hkl object to access within the store
+        store: accessor to the hkl object.
+        collection: collection within which the hkl object resides.
+
+    Returns:
+        Column vector in List[List[float]] format, or None
+
+    """
+    hklcalc = await store.load(name, collection)
+    ubcalc: UBCalculation = hklcalc.ubcalc
+
+    n_hkl = ubcalc.n_hkl
+    return n_hkl.tolist() if n_hkl is not None else None
+
+
+async def get_lab_surface_normal(
+    name: str,
+    store: HklCalcStore,
+    collection,
+) -> Optional[List[List[float]]]:
+    """Get the surface normal surf_nphi.
+
+    Args:
+        name: the name of the hkl object to access within the store
+        store: accessor to the hkl object.
+        collection: collection within which the hkl object resides.
+
+    Returns:
+        Column vector in List[List[float]] format, or None
+
+    """
+    hklcalc = await store.load(name, collection)
+    ubcalc: UBCalculation = hklcalc.ubcalc
+
+    surf_nphi = ubcalc.surf_nphi
+    return surf_nphi.tolist() if surf_nphi is not None else None
+
+
+async def get_miller_surface_normal(
+    name: str,
+    store: HklCalcStore,
+    collection,
+) -> Optional[List[List[float]]]:
+    """Get the surface normal surf_nhkl.
+
+    Args:
+        name: the name of the hkl object to access within the store
+        store: accessor to the hkl object.
+        collection: collection within which the hkl object resides.
+
+    Returns:
+        Column vector in List[List[float]] format, or None
+
+    """
+    hklcalc = await store.load(name, collection)
+    ubcalc: UBCalculation = hklcalc.ubcalc
+
+    surf_nhkl = ubcalc.surf_nhkl
+    return surf_nhkl.tolist() if surf_nhkl is not None else None

--- a/tests/test_ubcalc.py
+++ b/tests/test_ubcalc.py
@@ -1,5 +1,6 @@
 import ast
 from ast import literal_eval
+from typing import Dict
 
 import numpy as np
 import pytest
@@ -434,24 +435,37 @@ def test_set_ub():
     )
 
 
-def test_modify_property():
+@pytest.mark.parametrize(
+    ["url", "body", "property"],
+    [
+        ["/ub/test/nhkl?collection=B07", {"h": 0, "k": 0, "l": 1}, "n_hkl"],
+        ["/ub/test/nphi?collection=B07", {"x": 0, "y": 0, "z": 1}, "n_phi"],
+        ["/ub/test/surface/nhkl?collection=B07", {"h": 0, "k": 0, "l": 1}, "surf_nhkl"],
+        ["/ub/test/surface/nphi?collection=B07", {"x": 0, "y": 0, "z": 1}, "surf_nphi"],
+    ],
+)
+def test_get_and_set_reference_vectors_hkl(
+    url: str, body: Dict[str, float], property: str
+):
     ubcalc = UBCalculation()
     hkl = HklCalculation(ubcalc, Constraints())
     client = Client(hkl).client
-    response = client.put(
-        "/ub/test/n_hkl",
-        json={"h": 0, "k": 0, "l": 1},
+    response_put = client.put(
+        url,
+        json=body,
     )
 
-    assert response.status_code == 200
-    assert np.all(ubcalc.n_hkl == np.transpose([[0, 0, 1]]))
+    if property.endswith("hkl"):
+        body_as_array = np.array([[body["h"], body["k"], body["l"]]])
+    else:
+        body_as_array = np.array([[body["x"], body["y"], body["z"]]])
 
+    assert response_put.status_code == 200
+    assert np.all(getattr(ubcalc, property) == np.transpose(body_as_array))
 
-def test_modify_non_existent_property():
-    hkl = HklCalculation(UBCalculation(), Constraints())
-    client = Client(hkl).client
-    response = client.put(
-        "/ub/test/silly_property",
-        json={"h": 0, "k": 0, "l": 1},
+    response_get = client.get(url)
+
+    assert np.all(
+        np.array(literal_eval(response_get.content.decode())["payload"]).T
+        == body_as_array
     )
-    assert response.status_code == ErrorCodes.INVALID_PROPERTY


### PR DESCRIPTION
Some functionality is missing which would be useful to have:
- getting the U/UB matrices directly.

This PR addresses this, but also modifies the routes for calculating ub and getting the status of it. Now the routes look like:

GET /ub/{name}/calculate - calculates the UB
GET /ub/{name}/ub - gets the UB matrix
GET /ub/{name}/u - gets the U matrix
GET /ub/{name}/status - gets the status of the UB object, i.e. a big string.