### PR TITLE
added dependabot config, and workflow to rebase dependencies branch o…

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,3 +15,4 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 100
+    target-branch: "dependencies"

--- a/.github/workflows/rebase-dependencies.yml
+++ b/.github/workflows/rebase-dependencies.yml
@@ -1,0 +1,19 @@
+name: Automatic Rebase
+on:
+  push:
+    branches:
+      - master
+jobs:
+  rebase:
+    name: Rebase `dependencies` with `master`
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0 # otherwise, you will fail to push refs to dest repo
+          ref: dependencies
+      - run: |
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+          git rebase origin/master
+          git push origin dependencies --force


### PR DESCRIPTION
Changed config so that dependabot makes PRs onto a protected "dependencies" branch. Also updated config so that on any push to master, this dependencies branch is rebased.

This will make it easier to manage dependabot changes in future, and the approach was inspired by this article: https://www.hacksoft.io/blog/managing-dependencies-with-github-dependabot-and-actions